### PR TITLE
Add a `contentEncoding` property to compressed files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,16 @@ module.exports = function (options) {
 				return;
 			}
 
-			if (config.append && wasCompressed) file.path += '.gz';
+			if (wasCompressed) {
+				if (file.contentEncoding) {
+					file.contentEncoding.push('gzip');
+				} else {
+					file.contentEncoding = [ 'gzip' ];
+				}
+				if (config.append) {
+					file.path += '.gz';
+				}
+			}
 			file.contents = contents;
 			self.push(file);
 			done();
@@ -50,7 +59,7 @@ module.exports = function (options) {
 		};
 
 		// Check if file contents is a buffer or a stream
-		if(file.isBuffer()) {
+		if (file.isBuffer()) {
 			bufferMode(file.contents, config, finished);
 		} else {
 			streamMode(file.contents, config, finished);

--- a/test/test.js
+++ b/test/test.js
@@ -349,7 +349,7 @@ describe('gulp-gzip', function() {
 			});
 		});
 
-		describe('preserve file properties', function() {
+		describe('file properties', function() {
 			it('should not lose any properties from the Vinyl file', function(done) {
 				gulp.src('files/small.txt')
 					.pipe(tap(function(file) {
@@ -358,6 +358,16 @@ describe('gulp-gzip', function() {
 					.pipe(gzip())
 					.pipe(tap(function(file) {
 						file.should.have.property('test', 'test');
+						done();
+					}));
+			});
+
+			it('should set `contentEncoding`', function(done) {
+				gulp.src('files/small.txt')
+					.pipe(gzip())
+					.pipe(tap(function(file) {
+						file.should.have.property('contentEncoding');
+						file.contentEncoding.should.containEql('gzip');
 						done();
 					}));
 			});


### PR DESCRIPTION
This can be used later on by other parts of a pipeline to:
 * Tell that data was indeed compressed (without brittle extension checking),
 * Tell how the data was compressed.

It follows roughly the same semantics as the HTTP 'Content-Encoding' header and allows a consumer of the file to observe all the encoding processes that occurred on the file. See: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html section 14.11.