### PR TITLE
Add extension and preExtension options to allow more complex renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,26 @@ Appends `.gz` file extension if true. Defaults to true.
 
 ```javascript
  gzip({ append: true })
- ```
+```
+`filename.txt` becomes `filename.txt.gz`.
+
+### extension `String`
+
+Appends an arbitrary extension to the filename. Disables `append` and `preExtension` options.
+
+```javascript
+ gzip({ extension: 'zip' }) // note that the `.` should not be included in the extension
+```
+`filename.txt` becomes `filename.txt.zip`.
+
+### preExtension `String`
+
+Appends an arbitrary pre-extension to the filename. Disables `append` and `extension` options.
+
+```javascript
+ gzip({ preExtension: 'gz' }) // note that the `.` should not be included in the extension
+```
+`filename.txt` becomes `filename.gz.txt`.
 
 ### threshold `String|Number|Boolean`
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,11 @@ module.exports = function (options) {
         } else {
           file.contentEncoding = [ 'gzip' ];
         }
-        if (config.append) {
+        if (config.extension) {
+            file.path += '.' + config.extension;
+        } else if (config.preExtension) {
+            file.path = file.path.replace(/(\.[^\.]+)$/, '.' + config.preExtension + '$1');
+        } else if (config.append) {
           file.path += '.gz';
         }
       }

--- a/test/test.js
+++ b/test/test.js
@@ -99,6 +99,24 @@ describe('gulp-gzip', function() {
             done();
           }));
       });
+
+      it('should accept an arbitrary extension with the `extension` option', function(done) {
+          gulp.src('files/small.txt')
+            .pipe(gzip({ extension: 'zip' }))
+            .pipe(tap(function(file) {
+              file.path.should.endWith('.zip');
+              done();
+            }));
+      });
+
+      it('should accept an arbitrary pre-extension with the `preExtension` option', function(done) {
+          gulp.src('files/small.txt')
+            .pipe(gzip({ preExtension: 'gz' }))
+            .pipe(tap(function(file) {
+              file.path.should.endWith('.gz.txt');
+              done();
+            }));
+      });
     });
 
     describe('buffer mode', function() {


### PR DESCRIPTION
I needed to be able to rename `filename.css` to `filename.gz.css`, to serve these files with `Content-Encoding: 'gzip'` and preserve mime-type detection.