### PR TITLE
Add deleteMode option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ gzip({ gzipOptions: { level: 9 } })
 gzip({ gzipOptions: { memLevel: 1 } })
 ```
 
+### deleteMode `String|Function`
+
+Some webserver modules such as nginx `gzip_static` looks for `example.html.gz`, serve it if it exists, else the original `example.html` will be served.
+
+For instance, if `example.html` was 2kb, it would be gzipped and `example.html.gz` was created.
+
+However, if later `example.html` is modified to content less than the threshold, gulp-gzip will only bypass it. Hence, you will end up with a new `example.html` yet old `example.html.gz`. Your webserver will continue to serve old content (`example.html.gz`).
+
+Using this option, gulp-gzip will remove `example.html.gz`.
+
+It takes in the same argument as `gulp.dest` as in `gulp.dest('mydest')`, so it knows where to look for the gzipped files. Defaults to `undefined`.
+
+```javascript
+gzip({ threshold: 1024, deleteMode: 'mydest' })
+```
+
+If you have `cwd` as in `gulp.dest('mydest', { cwd: mycwd })`. You can configure it using `deleteModeCwd`.
+
+```javascript
+gzip({ threshold: 1024, deleteMode: 'mydest', deleteModeCwd: mycwd })
+```
+
 #Examples
 
 ```javascript

--- a/test/test.js
+++ b/test/test.js
@@ -119,6 +119,74 @@ describe('gulp-gzip', function() {
       });
     });
 
+    describe('delete mode', function() {
+
+      it('should not delete existing gzipped files when { deleteMode : false }', function(done) {
+        var id = nid();
+        var out = gulp.dest('tmp');
+
+        out.on('end', function() {
+          fs.readFile('./tmp/' + id + '.txt.gz', function(err, file) {
+            should.not.exist(err);
+            should.exist(file);
+            file.should.not.be.empty;
+
+            var out = gulp.dest('tmp');
+            out.on('end', function() {
+              fs.readFile('./tmp/' + id + '.txt.gz', function(err, file) {
+                should.not.exist(err);
+                should.exist(file);
+                file.should.not.be.empty;
+                done();
+              });
+            });
+
+            gulp.src('files/small.txt')
+              .pipe(rename({ basename: id }))
+              .pipe(gzip({ threshold: 1024 }))
+              .pipe(out);
+          });
+        });
+
+        gulp.src('files/big.txt')
+          .pipe(rename({ basename: id }))
+          .pipe(gzip({ threshold: 1024 }))
+          .pipe(out);
+      });
+
+      it('should delete existing gzipped files if the files changed from big.txt (over threshold) to small.txt (under threshold) when { deleteMode : true }', function(done) {
+        var id = nid();
+        var out = gulp.dest('tmp');
+
+        out.on('end', function() {
+          fs.readFile('./tmp/' + id + '.txt.gz', function(err, file) {
+            should.not.exist(err);
+            should.exist(file);
+            file.should.not.be.empty;
+
+            var out = gulp.dest('tmp');
+
+            out.on('end', function() {
+              fs.exists('./tmp/' + id + '.txt.gz', function(exists) {
+                exists.should.be.false;
+                done();
+              });
+            });
+
+            gulp.src('files/small.txt')
+              .pipe(rename({ basename: id }))
+              .pipe(gzip({ threshold: 1024, deleteMode: 'tmp' }))
+              .pipe(out);
+          });
+        });
+
+        gulp.src('files/big.txt')
+          .pipe(rename({ basename: id }))
+          .pipe(gzip({ threshold: 1024, deleteMode: 'tmp' }))
+          .pipe(out);
+      });
+    });
+
     describe('buffer mode', function() {
 
       it('should create file with .gz extension, by default', function(done) {


### PR DESCRIPTION
Some webserver modules such as nginx `gzip_static` looks for
`example.html.gz`, serve it if it exists, else the original
`example.html` will be served.

For instance, if `example.html` was 2kb, it would be gzipped and
`example.html.gz` was created.

However, if later `example.html` is modified to content less than the
threshold, gulp-gzip will only bypass it. Hence, you will end up with a
new `example.html` yet old `example.html.gz`. Your webserver will
continue to serve old content (`example.html.gz`).