### PR TITLE
Update production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
   ],
   "dependencies": {
     "ansi-colors": "^1.0.1",
-    "bytes": "^0.3.0",
+    "bytes": "^3.0.0",
     "fancy-log": "^1.3.2",
-    "plugin-error": "^0.1.2",
-    "stream-to-array": "~1.0.0",
-    "through2": "^0.4.1"
+    "plugin-error": "^1.0.0",
+    "stream-to-array": "^2.3.0",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
     "gulp": "^3.6.2",


### PR DESCRIPTION
Fixes gulp-util warning when requiring package

> warning gulp-gzip > through2 > xtend > object-keys@0.4.0: