### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gulp-gzip",
   "version": "1.4.1",
+  "license": "MIT",
   "description": "Gzip plugin for gulp.",
   "keywords": [
     "compress",


### PR DESCRIPTION
Added the MIT license as it appears on https://www.npmjs.com/package/gulp-gzip

Fixes the warning:

> npm WARN gulp-gzip@1.4.1 No license field.